### PR TITLE
Fix `release_to_main` job

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -160,7 +160,7 @@ jobs:
           persist-credentials: false
       - name: Sync main
         run: |
-          git fetch origin release
+          git fetch origin ci-release
           git merge --ff-only origin/ci-release
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0


### PR DESCRIPTION
The job was fetching wrong release branch, it should be `ci-release`