### PR TITLE
Make staging profile optional

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -49,7 +49,7 @@ on:
       SIGNING_KEY:
         required: true
       SONATYPE_STAGING_PROFILE_ID:
-        required: true
+        required: false
       STREAM_PUBLIC_BOT_TOKEN:
         required: true
 


### PR DESCRIPTION
Central portal doesn't need this anymore, so I'm making it optional